### PR TITLE
Fix for deprecated torch string_classes import

### DIFF
--- a/data/dataset_3d.py
+++ b/data/dataset_3d.py
@@ -435,7 +435,7 @@ class ShapeNet(data.Dataset):
 
 import collections.abc as container_abcs
 int_classes = int
-from torch._six import string_classes
+string_classes = str
 
 import re
 default_collate_err_msg_format = (


### PR DESCRIPTION
This commit fixes a deprecated import statement in the codebase that uses the string_classes module from PyTorch. The deprecated import statement from torch import string_classes has been replaced with a simpler and more Pythonic alternative string_classes = str.

The string_classes module was previously used to define the type of a string, but it has been removed in more recent versions of PyTorch. This commit provides a cleaner and more compatible solution that works with newer versions of PyTorch.

See https://github.com/pytorch/pytorch/pull/94709