### PR TITLE
Sample input dimensions in PointMLP

### DIFF
--- a/models/pointmlp/pointMLP.py
+++ b/models/pointmlp/pointMLP.py
@@ -363,8 +363,9 @@ def pointMLPElite(**kwargs) -> Model:
                    k_neighbors=[24,24,24,24], reducers=[2, 2, 2, 2], **kwargs)
 
 if __name__ == '__main__':
-    data = torch.rand(2, 3, 1024)
+    # Sample input data
+    data = torch.rand(5, 1024, 3) # 5 point clouds with 1024 points each
     print("===> testing pointMLP ...")
     model = pointMLP()
     out = model(data)
-    print(out.shape)
+    print(out.shape) # Output: torch.Size([5, 256])


### PR DESCRIPTION
## Main Features of this PR

- While trying to run `python models/pointMLP.py`, the following runtime error was raised due to ill-specification of the sample input dimensions: ``` RuntimeError: Given groups=1, weight of size [64, 3, 1], expected input[2, 1024, 3] to have 3 channels, but got 1024 channels instead ``` 
- This PR fixes the issue and the outputs are now `[#input_point_clouds x 256]`.